### PR TITLE
build: add pypdf

### DIFF
--- a/tutorial-scipy-2024/environment.yml
+++ b/tutorial-scipy-2024/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - langchain-community==0.2.1
   - libopenblas
   - nltk
+  - pypdf
   - tqdm
   - fsspec
   - gcsfs


### PR DESCRIPTION
adding dependency for PyPdfLoader in Document Loader appendix.

https://python.langchain.com/v0.1/docs/modules/data_connection/document_loaders/pdf/#using-pypdf